### PR TITLE
Improve unit tests

### DIFF
--- a/src/parser/structured_data.rs
+++ b/src/parser/structured_data.rs
@@ -90,9 +90,10 @@ mod tests {
     use super::*;
 
     #[test]
-    fn simple_structured_data() {
+    fn simple_structured_data1() {
+        let msg = "[a]";
         assert_eq!(
-            <Vec<StructuredData> as ParsePart>::parse("[a]")
+            <Vec<StructuredData> as ParsePart>::parse(msg)
                 .expect("parsing data")
                 .1,
             vec![StructuredData {
@@ -100,13 +101,15 @@ mod tests {
                 params: vec![]
             }]
         );
+    }
 
+    #[test]
+    fn simple_structured_data2() {
+        let msg = r#"[exampleSDID@32473 iut="3" eventSource="Application" eventID="1011"]"#;
         assert_eq!(
-            <Vec<StructuredData> as ParsePart>::parse(
-                "[exampleSDID@32473 iut=\"3\" eventSource=\"Application\" eventID=\"1011\"]"
-            )
-            .expect("parsing data")
-            .1,
+            <Vec<StructuredData> as ParsePart>::parse(msg)
+                .expect("parsing data")
+                .1,
             vec![StructuredData {
                 id: "exampleSDID@32473",
                 params: vec![
@@ -128,9 +131,10 @@ mod tests {
     }
 
     #[test]
-    fn simple_structured_data_inner() {
+    fn simple_structured_data_inner1() {
+        let msg = "a";
         assert_eq!(
-            parse_structured_data_inner("a"),
+            parse_structured_data_inner(msg),
             Ok((
                 "",
                 StructuredData {
@@ -139,9 +143,13 @@ mod tests {
                 }
             ))
         );
+    }
 
+    #[test]
+    fn simple_structured_data_inner2() {
+        let msg = r#"a key="value" anotherkey="anothervalue""#;
         assert_eq!(
-            parse_structured_data_inner(r#"a key="value" anotherkey="anothervalue""#),
+            parse_structured_data_inner(msg),
             Ok((
                 "",
                 StructuredData {
@@ -159,11 +167,13 @@ mod tests {
                 }
             ))
         );
+    }
 
+    #[test]
+    fn simple_structured_data_inner3() {
+        let msg = r#"exampleSDID@32473 iut="3" eventSource="Application" eventID="1011""#;
         assert_eq!(
-            parse_structured_data_inner(
-                "exampleSDID@32473 iut=\"3\" eventSource=\"Application\" eventID=\"1011\""
-            ),
+            parse_structured_data_inner(msg),
             Ok((
                 "",
                 StructuredData {


### PR DESCRIPTION
Rsyslog has both unit and integration tests. The former test small parts of the library while the latter test the library from a higher perspective.

It seems that the unit tests are written in a non-idiomatic way: each test function would accomodate multiple test scenarios (and assertions). This is not optimal as it's better to isolate each unit test to the specific scenario it actually tests.

Let's fix this. In this commit we update the unit tests found under `structured_data.rs` file to follow the pattern suggested above, where each unit test actually tests only a single scenario.